### PR TITLE
(GCW0/RS90) Enable configuration of the button combo used to toggle the menu

### DIFF
--- a/source/opendingux/gui.c
+++ b/source/opendingux/gui.c
@@ -1432,7 +1432,12 @@ static struct MenuEntry HotkeyMenu_FastForward = {
 	ENTRY_OPTIONAL_HOTKEY
 };
 
-#if !defined GCW_ZERO
+#if (defined(GCW_ZERO) || defined(RS90))
+static struct MenuEntry HotkeyMenu_MenuToggleCombo = {
+	ENTRY_OPTION("menu_toggle_combo", "Menu", &MenuToggleCombo),
+	.ChoiceCount = 4, .Choices = { { "Power/Start+Select", "power_or_start_select" }, { "Power/L3+R3", "power_or_l3_r3" }, { "Power", "power" },  { "Start+Select", "start_select" } }
+};
+#else
 static struct MenuEntry HotkeyMenu_Menu = {
 	ENTRY_OPTION("hotkey_menu", "Menu", &Hotkeys[1]),
 	ENTRY_MANDATORY_HOTKEY
@@ -1476,10 +1481,10 @@ static struct Menu HotkeyMenu = {
 	.Parent = &MainMenu, .Title = "Hotkeys",
 	.AlternateVersion = &PerGameHotkeyMenu,
 	.Entries = {
-#if !defined GCW_ZERO
-		&HotkeyMenu_Menu,
+#if (defined(GCW_ZERO) || defined(RS90))
+		&HotkeyMenu_MenuToggleCombo,
 #else
-		&Strut,
+		&HotkeyMenu_Menu,
 #endif
 		&HotkeyMenu_FastForward, &HotkeyMenu_FastForwardToggle, &HotkeyMenu_QuickLoadState, &HotkeyMenu_QuickSaveState, NULL
 	}

--- a/source/opendingux/od-input.h
+++ b/source/opendingux/od-input.h
@@ -80,6 +80,18 @@ enum Joystick_Stick_Axis {
 	JS_AXIS_RIGHT_VERTICAL   = 3,
 };
 
+#if (defined(GCW_ZERO) || defined(RS90))
+/* Note: We do not offer an L3+R3 combo *without*
+ * power, since this would lock users out of the
+ * menu on devices without L3/R3 buttons */
+enum Menu_Toggle_Combo {
+	MENU_TOGGLE_POWER_OR_START_SELECT = 0,
+	MENU_TOGGLE_POWER_OR_L3_R3        = 1,
+	MENU_TOGGLE_POWER                 = 2,
+	MENU_TOGGLE_START_SELECT          = 3,
+};
+#endif
+
 // 0 if not fast-forwarding.
 // Otherwise, the amount of frames to skip per rendered frame.
 // 1 amounts to targetting 200% real-time;
@@ -173,6 +185,15 @@ extern enum OpenDingux_Buttons KeypadRemapping[12];
 // [4] = Quick save state #1
 extern enum OpenDingux_Buttons PerGameHotkeys[5];
 extern enum OpenDingux_Buttons Hotkeys[5];
+
+#if (defined(GCW_ZERO) || defined(RS90))
+// A value indicating which button combos will open the menu.
+// 0 means POWER or START+SELECT
+// 1 means POWER or L3+R3
+// 2 means POWER
+// 3 means START+SELECT
+extern uint32_t MenuToggleCombo;
+#endif
 
 /*
  * Returns true if the given hotkey is completely impossible to input on the

--- a/source/opendingux/settings.c
+++ b/source/opendingux/settings.c
@@ -203,6 +203,10 @@ static void FixUpSettings()
 	if (IsImpossibleHotkey(PerGameHotkeys[4]))
 		PerGameHotkeys[4] = 0;
 
+#if (defined(GCW_ZERO) || defined(RS90))
+	MenuToggleCombo = (MenuToggleCombo > MENU_TOGGLE_START_SELECT) ? MENU_TOGGLE_START_SELECT : MenuToggleCombo;
+#endif
+
 	/* Colour correction and interframe blending options
 	 * are converted to an enum via bit manipulation. It
 	 * is therefore essential that the associated settings


### PR DESCRIPTION
(GCW0/RS90) Enable configuration of the button combo used to toggle the menu:

- POWER or START+SELECT
- POWER or L3+R3
- POWER
- START+SELECT

Enables POWER button to be disabled, for users of simple menu/Adam image (where waking from sleep would otherwise cause the ReGBA menu to open)